### PR TITLE
 Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/core/src/main/java/com/mygeopay/core/coins/CoinType.java
+++ b/core/src/main/java/com/mygeopay/core/coins/CoinType.java
@@ -73,6 +73,10 @@ abstract public class CoinType extends NetworkParameters implements ValueType, S
         return checkNotNull(unitExponent, "A coin failed to set a unit exponent");
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @return
+     */
     @Deprecated
     public Coin getFeePerKb() {
         return feePerKb().toCoin();
@@ -82,6 +86,10 @@ abstract public class CoinType extends NetworkParameters implements ValueType, S
         return checkNotNull(feePerKb, "A coin failed to set a fee per kilobyte");
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @return
+     */
     @Deprecated
     public Coin getMinNonDust() {
         return minNonDust().toCoin();
@@ -92,6 +100,10 @@ abstract public class CoinType extends NetworkParameters implements ValueType, S
         return checkNotNull(minNonDust, "A coin failed to set a minimum amount to be considered not dust");
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @return
+     */
     @Deprecated
     public Coin getSoftDustLimit() {
         return softDustLimit().toCoin();
@@ -135,6 +147,7 @@ abstract public class CoinType extends NetworkParameters implements ValueType, S
     }
 
     /**
+     * @deprecated kept for backward compatibility
      * Returns a 1 coin of this type with the correct amount of units (satoshis)
      * Use {@linkcom.mygeopay.core.coins.CoinType:oneCoin}
      */

--- a/wallet/src/main/java/com/mygeopay/wallet/Configuration.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/Configuration.java
@@ -32,6 +32,9 @@ public class Configuration {
 
     private static final String PREFS_KEY_LAST_VERSION = "last_version";
     private static final String PREFS_KEY_LAST_USED = "last_used";
+    /**
+     * @deprecated kept for backward compatibility
+     */
     @Deprecated
     private static final String PREFS_KEY_LAST_POCKET = "last_pocket";
     private static final String PREFS_KEY_LAST_ACCOUNT = "last_account";

--- a/wallet/src/main/java/com/mygeopay/wallet/util/Keyboard.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/util/Keyboard.java
@@ -10,7 +10,11 @@ import android.widget.TextView;
  * @author John L. Jegutanis
  */
 public class Keyboard {
-
+    /**
+     * @deprecated kept for backward compatibility
+     * @param textView
+     * @param activity
+     */
     // FIXME causes problems in older Androids
     @Deprecated
     public static void focusAndShowKeyboard(final TextView textView, final Activity activity) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.
