### PR TITLE
Methods named "equals" should override Object.equals(Object)

### DIFF
--- a/core/src/main/java/com/mygeopay/core/coins/CoinType.java
+++ b/core/src/main/java/com/mygeopay/core/coins/CoinType.java
@@ -214,7 +214,7 @@ abstract public class CoinType extends NetworkParameters implements ValueType, S
     }
 
     @Override
-    public boolean equals(ValueType obj) {
+    public boolean isEquals(ValueType obj) {
         return super.equals(obj);
     }
 }

--- a/core/src/main/java/com/mygeopay/core/coins/FiatType.java
+++ b/core/src/main/java/com/mygeopay/core/coins/FiatType.java
@@ -99,7 +99,7 @@ public class FiatType implements ValueType {
     }
 
     @Override
-    public boolean equals(ValueType o) {
+    public boolean isEquals(ValueType o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         return currencyCode.equals(o.getSymbol());

--- a/core/src/main/java/com/mygeopay/core/coins/ValueType.java
+++ b/core/src/main/java/com/mygeopay/core/coins/ValueType.java
@@ -31,7 +31,7 @@ public interface ValueType extends Serializable {
     public MonetaryFormat getMonetaryFormat();
     public MonetaryFormat getPlainFormat();
 
-    public boolean equals(ValueType obj);
+    public boolean isEquals(ValueType obj);
 
     Value value(String string);
 }

--- a/core/src/main/java/com/mygeopay/core/wallet/AddressWallet.java
+++ b/core/src/main/java/com/mygeopay/core/wallet/AddressWallet.java
@@ -82,7 +82,7 @@ public class AddressWallet extends AbstractWallet {
     }
 
     @Override
-    public boolean equals(WalletAccount otherAccount) {
+    public boolean isEquals(WalletAccount otherAccount) {
         return false;
     }
 

--- a/core/src/main/java/com/mygeopay/core/wallet/WalletAccount.java
+++ b/core/src/main/java/com/mygeopay/core/wallet/WalletAccount.java
@@ -73,7 +73,7 @@ public interface WalletAccount extends TransactionBag, KeyBag, TransactionEventL
     void encrypt(KeyCrypter keyCrypter, KeyParameter aesKey);
     void decrypt(KeyParameter aesKey);
 
-    boolean equals(WalletAccount otherAccount);
+    boolean isEquals(WalletAccount otherAccount);
 
     void addEventListener(WalletAccountEventListener listener);
     void addEventListener(WalletAccountEventListener listener, Executor executor);

--- a/core/src/main/java/com/mygeopay/core/wallet/WalletPocketHD.java
+++ b/core/src/main/java/com/mygeopay/core/wallet/WalletPocketHD.java
@@ -108,7 +108,7 @@ public class WalletPocketHD extends AbstractWallet {
 
 
     @Override
-    public boolean equals(WalletAccount other) {
+    public boolean isEquals(WalletAccount other) {
         return other != null &&
                 getId().equals(other.getId()) &&
                 getCoinType().equals(other.getCoinType());

--- a/wallet/src/main/java/com/mygeopay/wallet/ui/TradeSelectFragment.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/ui/TradeSelectFragment.java
@@ -546,7 +546,7 @@ public class TradeSelectFragment extends Fragment {
                 if (entry.accountOrCoinType instanceof WalletAccount) {
                     WalletAccount newSource = (WalletAccount) entry.accountOrCoinType;
                     // If same account selected, do nothing
-                    if (newSource.equals(sourceAccount)) return;
+                    if (newSource.isEquals(sourceAccount)) return;
                     // If new source and destination are the same, swap accounts
                     if (destinationAccount != null && destinationAccount.isType(newSource)) {
                         // Swap accounts
@@ -578,7 +578,7 @@ public class TradeSelectFragment extends Fragment {
                 if (entry.accountOrCoinType instanceof WalletAccount) {
                     WalletAccount newDestination = (WalletAccount) entry.accountOrCoinType;
                     // If same account selected, do nothing
-                    if (newDestination.equals(destinationAccount)) return;
+                    if (newDestination.isEquals(destinationAccount)) return;
                     // If new destination and source are the same, swap accounts
                     if (destinationAccount != null && sourceAccount.isType(newDestination)) {
                         // Swap accounts


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S1201 - Methods named "equals" should override Object.equals(Object)
You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1201
Please let me know if you have any questions.
Ayman Abdelghany.
