### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/wallet/src/main/java/com/mygeopay/wallet/ui/adaptors/AvailableAccountsAdaptor.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/ui/adaptors/AvailableAccountsAdaptor.java
@@ -58,6 +58,14 @@ public class AvailableAccountsAdaptor extends BaseAdapter {
             return result;
         }
 
+        @Override
+        public int hashCode() {
+            int result = this.iconRes;
+            result = 31 * result + (this.title != null ? this.title.hashCode() : 0);
+            result = 31 * result + (this.accountOrCoinType != null ? this.accountOrCoinType.hashCode() : 0);
+            return result;
+        }
+
         public CoinType getType() {
             if (accountOrCoinType instanceof CoinType) {
                 return (CoinType) accountOrCoinType;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.
