### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/core/src/main/java/com/mygeopay/core/protos/Protos.java
+++ b/core/src/main/java/com/mygeopay/core/protos/Protos.java
@@ -799,10 +799,10 @@ public final class Protos {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if ((bitField0_ & 0x00000001) == 0x00000001) {
         output.writeBytes(1, initialisationVector_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if ((bitField0_ & 0x00000002) == 0x00000002) {
         output.writeBytes(2, encryptedPrivateKey_);
       }
       getUnknownFields().writeTo(output);
@@ -814,11 +814,11 @@ public final class Protos {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if ((bitField0_ & 0x00000001) == 0x00000001) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, initialisationVector_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if ((bitField0_ & 0x00000002) == 0x00000002) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, encryptedPrivateKey_);
       }
@@ -971,11 +971,11 @@ public final class Protos {
        com.mygeopay.core.protos.Protos.EncryptedData result = new com.mygeopay.core.protos.Protos.EncryptedData(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if ((from_bitField0_ & 0x00000001) == 0x00000001) {
           to_bitField0_ |= 0x00000001;
         }
         result.initialisationVector_ = initialisationVector_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if ((from_bitField0_ & 0x00000002) == 0x00000002) {
           to_bitField0_ |= 0x00000002;
         }
         result.encryptedPrivateKey_ = encryptedPrivateKey_;
@@ -1363,7 +1363,7 @@ public final class Protos {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if ((mutable_bitField0_ & 0x00000002) == 0x00000002) {
           path_ = java.util.Collections.unmodifiableList(path_);
         }
         this.unknownFields = unknownFields.build();
@@ -1559,19 +1559,19 @@ public final class Protos {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if ((bitField0_ & 0x00000001) == 0x00000001) {
         output.writeBytes(1, chainCode_);
       }
       for (int i = 0; i < path_.size(); i++) {
         output.writeUInt32(2, path_.get(i));
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if ((bitField0_ & 0x00000002) == 0x00000002) {
         output.writeUInt32(3, issuedSubkeys_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if ((bitField0_ & 0x00000004) == 0x00000004) {
         output.writeUInt32(4, lookaheadSize_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if ((bitField0_ & 0x00000008) == 0x00000008) {
         output.writeBool(5, isFollowing_);
       }
       getUnknownFields().writeTo(output);
@@ -1583,7 +1583,7 @@ public final class Protos {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if ((bitField0_ & 0x00000001) == 0x00000001) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, chainCode_);
       }
@@ -1596,15 +1596,15 @@ public final class Protos {
         size += dataSize;
         size += 1 * getPathList().size();
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if ((bitField0_ & 0x00000002) == 0x00000002) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(3, issuedSubkeys_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if ((bitField0_ & 0x00000004) == 0x00000004) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(4, lookaheadSize_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if ((bitField0_ & 0x00000008) == 0x00000008) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(5, isFollowing_);
       }
@@ -1768,24 +1768,24 @@ public final class Protos {
        com.mygeopay.core.protos.Protos.DeterministicKey result = new com.mygeopay.core.protos.Protos.DeterministicKey(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if ((from_bitField0_ & 0x00000001) == 0x00000001) {
           to_bitField0_ |= 0x00000001;
         }
         result.chainCode_ = chainCode_;
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        if ((bitField0_ & 0x00000002) == 0x00000002) {
           path_ = java.util.Collections.unmodifiableList(path_);
           bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.path_ = path_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if ((from_bitField0_ & 0x00000004) == 0x00000004) {
           to_bitField0_ |= 0x00000002;
         }
         result.issuedSubkeys_ = issuedSubkeys_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if ((from_bitField0_ & 0x00000008) == 0x00000008) {
           to_bitField0_ |= 0x00000004;
         }
         result.lookaheadSize_ = lookaheadSize_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if ((from_bitField0_ & 0x00000010) == 0x00000010) {
           to_bitField0_ |= 0x00000008;
         }
         result.isFollowing_ = isFollowing_;
@@ -2375,7 +2375,7 @@ public final class Protos {
             }
             case 26: {
              com.mygeopay.core.protos.Protos.EncryptedData.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if ((bitField0_ & 0x00000004) == 0x00000004) {
                 subBuilder = encryptedData_.toBuilder();
               }
               encryptedData_ = input.readMessage(com.mygeopay.core.protos.Protos.EncryptedData.PARSER, extensionRegistry);
@@ -2399,7 +2399,7 @@ public final class Protos {
             }
             case 50: {
              com.mygeopay.core.protos.Protos.DeterministicKey.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+              if ((bitField0_ & 0x00000020) == 0x00000020) {
                 subBuilder = deterministicKey_.toBuilder();
               }
               deterministicKey_ = input.readMessage(com.mygeopay.core.protos.Protos.DeterministicKey.PARSER, extensionRegistry);
@@ -2806,22 +2806,22 @@ public final class Protos {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if ((bitField0_ & 0x00000001) == 0x00000001) {
         output.writeEnum(1, type_.getNumber());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if ((bitField0_ & 0x00000002) == 0x00000002) {
         output.writeBytes(2, secretBytes_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if ((bitField0_ & 0x00000004) == 0x00000004) {
         output.writeMessage(3, encryptedData_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if ((bitField0_ & 0x00000008) == 0x00000008) {
         output.writeBytes(4, publicKey_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if ((bitField0_ & 0x00000010) == 0x00000010) {
         output.writeBytes(5, getLabelBytes());
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if ((bitField0_ & 0x00000020) == 0x00000020) {
         output.writeMessage(6, deterministicKey_);
       }
       getUnknownFields().writeTo(output);
@@ -2833,27 +2833,27 @@ public final class Protos {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if ((bitField0_ & 0x00000001) == 0x00000001) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(1, type_.getNumber());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if ((bitField0_ & 0x00000002) == 0x00000002) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, secretBytes_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if ((bitField0_ & 0x00000004) == 0x00000004) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, encryptedData_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if ((bitField0_ & 0x00000008) == 0x00000008) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, publicKey_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if ((bitField0_ & 0x00000010) == 0x00000010) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, getLabelBytes());
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if ((bitField0_ & 0x00000020) == 0x00000020) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, deterministicKey_);
       }

--- a/wallet/src/main/java/com/mygeopay/wallet/ui/MakeTransactionFragment.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/ui/MakeTransactionFragment.java
@@ -240,7 +240,7 @@ public class MakeTransactionFragment extends Fragment {
                         .create().show();
             }
         });
-        poweredByShapeShift.setVisibility((isExchangeNeeded() ? View.VISIBLE : View.GONE));
+        poweredByShapeShift.setVisibility(isExchangeNeeded() ? View.VISIBLE : View.GONE);
 
         return view;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
