### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/core/src/main/java/com/mygeopay/core/wallet/TransactionWatcherWallet.java
+++ b/core/src/main/java/com/mygeopay/core/wallet/TransactionWatcherWallet.java
@@ -597,7 +597,7 @@ abstract public class TransactionWatcherWallet implements WalletAccount {
     public List<AddressStatus> getAllAddressStatus() {
         lock.lock();
         try {
-            ArrayList<AddressStatus> statuses = new ArrayList<AddressStatus>(addressesStatus.size());
+            List<AddressStatus> statuses = new ArrayList<AddressStatus>(addressesStatus.size());
             for (Map.Entry<Address, String> status : addressesStatus.entrySet()) {
                 statuses.add(new AddressStatus(status.getKey(), status.getValue()));
             }

--- a/core/src/main/java/com/mygeopay/core/wallet/WalletPocketHD.java
+++ b/core/src/main/java/com/mygeopay/core/wallet/WalletPocketHD.java
@@ -503,8 +503,8 @@ public class WalletPocketHD extends AbstractWallet {
     public List<Address> getIssuedReceiveAddresses() {
         lock.lock();
         try {
-            ArrayList<DeterministicKey> issuedKeys = keys.getIssuedExternalKeys();
-            ArrayList<Address> receiveAddresses = new ArrayList<Address>();
+            List<DeterministicKey> issuedKeys = keys.getIssuedExternalKeys();
+            List<Address> receiveAddresses = new ArrayList<Address>();
 
             Collections.sort(issuedKeys, HD_KEY_COMPARATOR);
 
@@ -523,7 +523,7 @@ public class WalletPocketHD extends AbstractWallet {
     public Set<Address> getUsedAddresses() {
         lock.lock();
         try {
-            HashSet<Address> usedAddresses = new HashSet<Address>();
+            Set<Address> usedAddresses = new HashSet<Address>();
 
             for (Map.Entry<Address, String> entry : addressesStatus.entrySet()) {
                 if (entry.getValue() != null) {

--- a/wallet/src/main/java/com/mygeopay/wallet/ui/TradeSelectFragment.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/ui/TradeSelectFragment.java
@@ -405,7 +405,7 @@ public class TradeSelectFragment extends Fragment {
 
         // If we have only one source type, remove it as a destination
         if (sourceTypes.size() == 1) {
-            ArrayList<CoinType> typesWithoutSourceType = Lists.newArrayList(supportedTypes);
+            List<CoinType> typesWithoutSourceType = Lists.newArrayList(supportedTypes);
             typesWithoutSourceType.remove(sourceType);
             destinationAdapter.update(allAccounts, typesWithoutSourceType, true);
         } else {

--- a/wallet/src/main/java/com/mygeopay/wallet/ui/adaptors/AvailableAccountsAdaptor.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/ui/adaptors/AvailableAccountsAdaptor.java
@@ -105,7 +105,7 @@ public class AvailableAccountsAdaptor extends BaseAdapter {
     private static List<Entry> createEntries(final List<WalletAccount> accounts,
                                                       final List<CoinType> validTypes,
                                                       final boolean includeTypes) {
-        final ArrayList<CoinType> typesToAdd = Lists.newArrayList(validTypes);
+        final List<CoinType> typesToAdd = Lists.newArrayList(validTypes);
 
         final ImmutableList.Builder<Entry> listBuilder = ImmutableList.builder();
         for (WalletAccount account : accounts) {

--- a/wallet/src/main/java/com/mygeopay/wallet/util/Qr.java
+++ b/wallet/src/main/java/com/mygeopay/wallet/util/Qr.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -64,7 +65,7 @@ public class Qr
             // Make qr-code size multiples of baseSize
             int size = (int) (Math.max(Math.floor(maxSize / baseSize), 1) * baseSize);
 
-            final Hashtable<EncodeHintType, Object> hints = new Hashtable<EncodeHintType, Object>();
+            final Map<EncodeHintType, Object> hints = new Hashtable<EncodeHintType, Object>();
             hints.put(EncodeHintType.MARGIN, 0);
             hints.put(EncodeHintType.ERROR_CORRECTION, ERROR_CORRECTION_LV);
             final BitMatrix result = QR_CODE_WRITER.encode(content, BarcodeFormat.QR_CODE, size, size, hints);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
