### PR TITLE
 Nested "enum"s should not be declared static

### DIFF
--- a/core/src/main/java/com/mygeopay/core/exchange/shapeshift/data/ShapeShiftEmail.java
+++ b/core/src/main/java/com/mygeopay/core/exchange/shapeshift/data/ShapeShiftEmail.java
@@ -10,7 +10,7 @@ public class ShapeShiftEmail  extends ShapeShiftBase {
     public final Status status;
     public final String message;
 
-    public static enum Status {
+    public enum Status {
         SUCCESS, UNKNOWN
     }
 

--- a/core/src/main/java/com/mygeopay/core/exchange/shapeshift/data/ShapeShiftTime.java
+++ b/core/src/main/java/com/mygeopay/core/exchange/shapeshift/data/ShapeShiftTime.java
@@ -14,7 +14,7 @@ public class ShapeShiftTime extends ShapeShiftBase {
     public final Status status;
     public final int secondsRemaining;
 
-    public static enum Status {
+    public enum Status {
         PENDING, EXPIRED, UNKNOWN
     }
 

--- a/core/src/main/java/com/mygeopay/core/exchange/shapeshift/data/ShapeShiftTxStatus.java
+++ b/core/src/main/java/com/mygeopay/core/exchange/shapeshift/data/ShapeShiftTxStatus.java
@@ -22,7 +22,7 @@ public class ShapeShiftTxStatus extends ShapeShiftBase {
     public final Value outgoingValue;
     public final String transactionId;
 
-    public static enum Status {
+    public enum Status {
         NO_DEPOSITS, RECEIVED, COMPLETE, FAILED, UNKNOWN
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2786 - “Nested "enum"s should not be declared static”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2786
Please let me know if you have any questions.
Ayman Abdelghany.
